### PR TITLE
Increase max url length limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - TEST_POSTGRES_USER=postgres
   matrix:
     - TOX_ENV=py33
-    - TOX_ENV=py34
     - TOX_ENV=py35
     - TOX_ENV=py36
     - TOX_ENV=pypy3
@@ -30,15 +29,11 @@ matrix:
     - python: 3.5
       env: TOX_ENV=py33
     - python: 3.5
-      env: TOX_ENV=py34
-    - python: 3.5
       env: TOX_ENV=py36
     - python: 3.5
       env: TOX_ENV=pypy3
     - python: pypy3
       env: TOX_ENV=py33
-    - python: pypy3
-      env: TOX_ENV=py34
     - python: pypy3
       env: TOX_ENV=py35
     - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
       env: TOX_ENV=pypy3
 
 install:
+  - pip install --compile --no-cache-dir --global-option="--with-gnutls" pycurl
   - pip install tox
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
       env: TOX_ENV=pypy3
 
 install:
-  - pip install --compile --no-cache-dir --global-option="--with-gnutls" pycurl
+  - sudo apt-get install libgnutls28-dev
   - pip install tox
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
 
 install:
   - sudo apt-get install libgnutls28-dev
-  - pip install tox
+  - pip install tox==3.13.2
 
 script:
   - tox -e $TOX_ENV

--- a/openid/message.py
+++ b/openid/message.py
@@ -51,6 +51,10 @@ BARE_NS = oidutil.Symbol('Bare namespace')
 # response payload.  See OpenID 1.1 specification, Appendix D.
 OPENID1_URL_LIMIT = 2047
 
+# Increasing the limit based on maximum length of urls in different browsers
+# https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+INCREASED_OPENID_URL_LIMIT = 8000
+
 # All OpenID protocol fields.  Used to check namespace aliases.
 OPENID_PROTOCOL_FIELDS = [
     'ns',

--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -129,7 +129,7 @@ from openid.store.nonce import mkNonce
 from openid.server.trustroot import TrustRoot, verifyReturnTo
 from openid.association import Association, default_negotiator, getSecretSize
 from openid.message import Message, InvalidOpenIDNamespace, \
-     OPENID_NS, OPENID2_NS, IDENTIFIER_SELECT, OPENID1_URL_LIMIT
+    OPENID_NS, OPENID2_NS, IDENTIFIER_SELECT, INCREASED_OPENID_URL_LIMIT
 from openid.urinorm import urinorm
 
 HTTP_OK = 200
@@ -1048,7 +1048,7 @@ class OpenIDResponse(object):
         """
         if self.request.mode in BROWSER_REQUEST_MODES:
             if self.fields.getOpenIDNamespace() == OPENID2_NS and \
-               len(self.encodeToURL()) > OPENID1_URL_LIMIT:
+               len(self.encodeToURL()) > INCREASED_OPENID_URL_LIMIT:
                 return ENCODE_HTML_FORM
             else:
                 return ENCODE_URL
@@ -1696,7 +1696,7 @@ class ProtocolError(Exception):
         """
         if self.hasReturnTo():
             if self.openid_message.getOpenIDNamespace() == OPENID2_NS and \
-               len(self.encodeToURL()) > OPENID1_URL_LIMIT:
+               len(self.encodeToURL()) > INCREASED_OPENID_URL_LIMIT:
                 return ENCODE_HTML_FORM
             else:
                 return ENCODE_URL

--- a/openid/test/test_server.py
+++ b/openid/test/test_server.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse, parse_qsl, parse_qs
 from openid.server import server
 from openid import association, cryptutil, oidutil
 from openid.message import Message, OPENID_NS, OPENID2_NS, OPENID1_NS, \
-     IDENTIFIER_SELECT, no_default, OPENID1_URL_LIMIT
+     IDENTIFIER_SELECT, no_default, INCREASED_OPENID_URL_LIMIT
 from openid.store import memstore
 from openid.test.support import CatchLogs
 
@@ -73,7 +73,8 @@ class TestProtocolError(unittest.TestCase):
         self.assertEqual(result_args, expected_args)
 
     def test_browserWithReturnTo_OpenID2_POST(self):
-        return_to = "http://rp.unittest/consumer" + ('x' * OPENID1_URL_LIMIT)
+        return_to = "http://rp.unittest/consumer" + (
+            'x' * INCREASED_OPENID_URL_LIMIT)
         # will be a ProtocolError raised by Decode or CheckIDRequest.answer
         args = Message.fromPostArgs({
             'openid.ns':
@@ -100,7 +101,8 @@ class TestProtocolError(unittest.TestCase):
             args.getArg(OPENID_NS, 'return_to')))
 
     def test_browserWithReturnTo_OpenID1_exceeds_limit(self):
-        return_to = "http://rp.unittest/consumer" + ('x' * OPENID1_URL_LIMIT)
+        return_to = "http://rp.unittest/consumer" + (
+            'x' * INCREASED_OPENID_URL_LIMIT)
         # will be a ProtocolError raised by Decode or CheckIDRequest.answer
         args = Message.fromPostArgs({
             'openid.mode':
@@ -575,11 +577,11 @@ class TestEncode(unittest.TestCase):
             'claimed_id':
             request.identity,
             'return_to':
-            'x' * OPENID1_URL_LIMIT,
+            'x' * INCREASED_OPENID_URL_LIMIT,
         })
 
         self.assertTrue(response.renderAsForm())
-        self.assertTrue(len(response.encodeToURL()) > OPENID1_URL_LIMIT)
+        self.assertTrue(len(response.encodeToURL()) > INCREASED_OPENID_URL_LIMIT)
         self.assertTrue(response.whichEncoding() == server.ENCODE_HTML_FORM)
         webresponse = self.encode(response)
         self.assertTrue(response.toFormMarkup() in webresponse.body)
@@ -603,7 +605,7 @@ class TestEncode(unittest.TestCase):
             'claimed_id':
             request.identity,
             'return_to':
-            'x' * OPENID1_URL_LIMIT,
+            'x' * INCREASED_OPENID_URL_LIMIT,
         })
 
         form_markup = response.toFormMarkup({'foo': 'bar'})
@@ -628,7 +630,7 @@ class TestEncode(unittest.TestCase):
             'claimed_id':
             request.identity,
             'return_to':
-            'x' * OPENID1_URL_LIMIT,
+            'x' * INCREASED_OPENID_URL_LIMIT,
         })
         html = response.toHTML()
         self.assertTrue('<html>' in html)
@@ -658,11 +660,11 @@ class TestEncode(unittest.TestCase):
             'identity':
             request.identity,
             'return_to':
-            'x' * OPENID1_URL_LIMIT,
+            'x' * INCREASED_OPENID_URL_LIMIT,
         })
 
         self.assertFalse(response.renderAsForm())
-        self.assertTrue(len(response.encodeToURL()) > OPENID1_URL_LIMIT)
+        self.assertTrue(len(response.encodeToURL()) > INCREASED_OPENID_URL_LIMIT)
         self.assertTrue(response.whichEncoding() == server.ENCODE_URL)
         webresponse = self.encode(response)
         self.assertEqual(webresponse.headers['location'],

--- a/openid/test/test_server.py
+++ b/openid/test/test_server.py
@@ -74,7 +74,7 @@ class TestProtocolError(unittest.TestCase):
 
     def test_browserWithReturnTo_OpenID2_POST(self):
         return_to = "http://rp.unittest/consumer" + (
-            'x' * INCREASED_OPENID_URL_LIMIT)
+            'xx' * INCREASED_OPENID_URL_LIMIT)
         # will be a ProtocolError raised by Decode or CheckIDRequest.answer
         args = Message.fromPostArgs({
             'openid.ns':
@@ -577,11 +577,12 @@ class TestEncode(unittest.TestCase):
             'claimed_id':
             request.identity,
             'return_to':
-            'x' * INCREASED_OPENID_URL_LIMIT,
+            'xx' * INCREASED_OPENID_URL_LIMIT,
         })
 
         self.assertTrue(response.renderAsForm())
-        self.assertTrue(len(response.encodeToURL()) > INCREASED_OPENID_URL_LIMIT)
+        self.assertTrue(
+            len(response.encodeToURL()) > INCREASED_OPENID_URL_LIMIT)
         self.assertTrue(response.whichEncoding() == server.ENCODE_HTML_FORM)
         webresponse = self.encode(response)
         self.assertTrue(response.toFormMarkup() in webresponse.body)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@
 [tox]
 envlist =
     py33
-    py34
     py35
     py36
     pypy3


### PR DESCRIPTION
Why?
- Openid used with Python 2 returned url encoded response, but with Python 3, if the length of the encoded url exceeds 2047, form encoded response is returned which breaks existing flows.
To maintain backward compatibity, the length check has been increased to 8k characters keeping in mind the support in different browsers. 
Please note: the flow will still break in cases where the length exceeds 8k characters.

What?
- Increase max url length allowed
- Fix breaking test cases
- Fix gcc install issue for pycurl
- Remove python 3.4 env (will take this up later)